### PR TITLE
build: add support for `darwin/arm64`+`vscode`

### DIFF
--- a/packages/archway-test-tube/libarchway/go.mod
+++ b/packages/archway-test-tube/libarchway/go.mod
@@ -1,6 +1,6 @@
 module github.com/FloppyDisck/archway-test-tube
 
-go 1.22
+go 1.22.1
 
 require (
 	cosmossdk.io/api v0.7.0 // indirect


### PR DESCRIPTION
Funny enough, the build was failing on mac OS vscode because of the specified go version being `1.22` instead of more explicit `1.22.x`.

See the related issues:
- https://github.com/golang/go/issues/65568#issuecomment-1954876836
- https://github.com/golang/go/issues/62278#issuecomment-1933790368